### PR TITLE
[1.20] Block-picker support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.21
 
 # Mod Properties
-	mod_version = 1.1.2
+	mod_version = 1.2.0
 	maven_group = com.github.nyuppo
 	archives_base_name = hotbarcycle
 

--- a/src/main/java/com/github/nyuppo/HotbarCycleClient.java
+++ b/src/main/java/com/github/nyuppo/HotbarCycleClient.java
@@ -156,6 +156,47 @@ public class HotbarCycleClient implements ClientModInitializer {
         }
     }
 
+    public static void shiftRows(MinecraftClient client, int direction) {
+        if (client.interactionManager == null || client.player == null) {
+            return;
+        }
+
+        int[] swapMap = SwapMap.GetInventorySwapMap(direction);
+        for (int x=0; x<9; ++x) {
+            for (int i=0; i<4 && swapMap[x]!=x; ++i){
+                int from = x;
+                int to = swapMap[x];
+
+                clicker.swap(client, to, from);
+                swapMap[from] = swapMap[to];
+                swapMap[to] = to;
+            }
+        }
+
+        if (CONFIG.getPlaySound()) {
+            client.player.playSound(SoundEvents.ITEM_BOOK_PAGE_TURN, SoundCategory.MASTER, 0.5f, 1.5f);
+        }
+    }
+
+    public static void shiftSingle(MinecraftClient client, int x, int direction) {
+        if (client.interactionManager == null || client.player == null) {
+            return;
+        }
+
+        int[] swapMap = SwapMap.GetRowSwapMap(direction);
+        for (int i=0; i<4 && swapMap[x]!=x; ++i){
+            int to = swapMap[x];
+
+            clicker.swap(client, (to * 9) + x, x);
+            swapMap[0] = swapMap[to];
+            swapMap[to] = to;
+        }
+
+        if (CONFIG.getPlaySound()) {
+            client.player.playSound(SoundEvents.ITEM_BOOK_PAGE_TURN, SoundCategory.MASTER, 0.5f, 1.5f);
+        }
+    }
+
     private static Clicker getClicker() {
         if (FabricLoader.getInstance().isModLoaded("inventoryprofilesnext")) {
             LOGGER.info("Inventory Profiles Next was found, switching to compatible clicker!");
@@ -165,7 +206,7 @@ public class HotbarCycleClient implements ClientModInitializer {
         return new VanillaClicker();
     }
 
-    private static boolean isColumnEnabled(int columnIndex) {
+    public static boolean isColumnEnabled(int columnIndex) {
         return switch (columnIndex) {
             case 0 -> CONFIG.getEnableColumn0();
             case 1 -> CONFIG.getEnableColumn1();
@@ -176,6 +217,18 @@ public class HotbarCycleClient implements ClientModInitializer {
             case 6 -> CONFIG.getEnableColumn6();
             case 7 -> CONFIG.getEnableColumn7();
             case 8 -> CONFIG.getEnableColumn8();
+            default -> false;
+        };
+    }
+
+    public static boolean isRowEnabled(int y) {
+        return switch (y){
+            // The mix-up is intentional; Row 1 (bottom) in the config is the 
+            // last row (y=3) in the slot array.
+            case 1 -> CONFIG.getEnableRow3();
+            case 2 -> CONFIG.getEnableRow2();
+            case 3 -> CONFIG.getEnableRow1();
+            case 0 -> true;
             default -> false;
         };
     }

--- a/src/main/java/com/github/nyuppo/HotbarCycleClient.java
+++ b/src/main/java/com/github/nyuppo/HotbarCycleClient.java
@@ -184,8 +184,8 @@ public class HotbarCycleClient implements ClientModInitializer {
         }
 
         int[] swapMap = SwapMap.GetRowSwapMap(direction);
-        for (int i=0; i<4 && swapMap[x]!=x; ++i){
-            int to = swapMap[x];
+        for (int i=0; i<4 && swapMap[0]!=0; ++i){
+            int to = swapMap[0];
 
             clicker.swap(client, (to * 9) + x, x);
             swapMap[0] = swapMap[to];

--- a/src/main/java/com/github/nyuppo/SwapMap.java
+++ b/src/main/java/com/github/nyuppo/SwapMap.java
@@ -1,0 +1,93 @@
+package com.github.nyuppo;
+
+import static com.github.nyuppo.HotbarCycleClient.isRowEnabled;
+import static com.github.nyuppo.HotbarCycleClient.isColumnEnabled;
+
+public class SwapMap 
+{
+	/**
+	 * Simulates the cycling of a slot by 1 space up.
+	 * @param src The slot's row index.
+	 * @return The next enabled row, i.e the resulting row after a single cycle.
+	 * Or `src` if the row is disabled
+	 */
+	static public int	GetRollover(int src){
+		if (!isRowEnabled(src))
+			return src;
+
+		for (int offset=1; offset<4; ++offset) {
+			int dst = (src + offset) % 4;
+			if (isRowEnabled(dst))
+				return dst;
+		}
+
+		return src;
+	}
+
+	/**
+	 * Simulates the cycling of a column by 1 space up.
+	 * @return For each row, points to next enabled row.  Disabled rows point to
+	 * themselves.
+	 */
+	static public int[]	GetRolloverMap(){
+		int [] rolloverMap = new int[4];
+
+		for (int src=0; src<4; ++src)
+			rolloverMap[src] = GetRollover(src);
+
+		return rolloverMap;
+	}
+
+
+	/**
+	 * Simulates the cycling of any column by an arbitrary amount.
+	 * @param direction The amount  of  cycles.  Positive  values  cycle upward,
+	 * negative values cycle downward.
+	 * @return For each row index,  points to  the resulting row.  Disabled rows
+	 * point to themselve.
+	 */
+	static public int[]	GetRowSwapMap(int direction){
+		int[] rolloverMap = GetRolloverMap();
+		int[] swapMap = new int[4];
+
+		int swapableRowCount = 0;
+		for (int i=0; i<4; ++i)
+			if (isRowEnabled(i))
+				swapableRowCount++;
+		direction %= swapableRowCount;
+		if (direction < 0)
+			direction += swapableRowCount;
+
+		for (int i=0; i<4; ++i){
+			swapMap[i] = i;
+			for (int n=0; n<direction; ++n)
+				swapMap[i] = rolloverMap[swapMap[i]];
+		}
+
+		return swapMap;
+	}
+
+	/**
+	 * Simulates the cycling of a whole inventory by an arbitrary amount.
+	 * @param direction The amount  of  cycles.  Positive  values  cycle upward,
+	 * negative values cycle downward.
+	 * @return For each slot index, points to the resulting slot. Disabled slots
+	 * point to themselves.
+	 */
+	static public int[]	GetInventorySwapMap(int direction){
+		int[] swapMap = new int[4*9];
+		int[] rowSwap = GetRowSwapMap(direction);
+
+		for (int i=0; i<swapMap.length; ++i){
+			int x = i % 9;
+			int y = i / 9;
+
+			if (!isColumnEnabled(x) || !isRowEnabled(y))
+				swapMap[i] = i;
+			else 
+				swapMap[i] = (rowSwap[y] * 9) + x;
+		}
+
+		return swapMap;
+	}
+}

--- a/src/main/java/com/github/nyuppo/config/ClothConfigHotbarCycleConfig.java
+++ b/src/main/java/com/github/nyuppo/config/ClothConfigHotbarCycleConfig.java
@@ -12,6 +12,10 @@ public class ClothConfigHotbarCycleConfig extends HotbarCycleConfig implements C
     public boolean holdAndScroll = false;
     @ConfigEntry.Gui.Tooltip()
     public boolean repeatSlotToCycle = false;
+    @ConfigEntry.Gui.Tooltip()
+    public boolean cycleWhenPickingBlock = false;
+    @ConfigEntry.Gui.Tooltip()
+    public boolean pickCyclesWholeHotbar = false;
 
     @ConfigEntry.Category("rows")
     @ConfigEntry.Gui.Tooltip()
@@ -61,6 +65,16 @@ public class ClothConfigHotbarCycleConfig extends HotbarCycleConfig implements C
     @Override
     public boolean getRepeatSlotToCycle() {
         return repeatSlotToCycle;
+    }
+
+    @Override
+    public boolean getCycleWhenPickingBlock(){
+        return cycleWhenPickingBlock;
+    }
+
+    @Override
+    public boolean getPickCyclesWholeHotbar(){
+        return pickCyclesWholeHotbar;
     }
 
     @Override

--- a/src/main/java/com/github/nyuppo/config/DefaultHotbarCycleConfig.java
+++ b/src/main/java/com/github/nyuppo/config/DefaultHotbarCycleConfig.java
@@ -22,6 +22,17 @@ public class DefaultHotbarCycleConfig extends HotbarCycleConfig {
     }
 
     @Override
+    public boolean getCycleWhenPickingBlock(){
+        return false;
+    }
+
+    @Override
+    public boolean getPickCyclesWholeHotbar(){
+        return false;
+    }
+
+
+    @Override
     public boolean getEnableRow1() {
         return true;
     }

--- a/src/main/java/com/github/nyuppo/config/HotbarCycleConfig.java
+++ b/src/main/java/com/github/nyuppo/config/HotbarCycleConfig.java
@@ -21,27 +21,4 @@ public abstract class HotbarCycleConfig {
     public abstract boolean getEnableColumn6();
     public abstract boolean getEnableColumn7();
     public abstract boolean getEnableColumn8();
-
-    public boolean isRowEnabled(int y){
-        switch (y){
-            default: return false;
-            case 1: return getEnableRow1();
-            case 2: return getEnableRow2();
-            case 3: return getEnableRow3();
-        }
-    }
-
-    public boolean isColumnEnabled(int x){
-        switch (x){
-            default: return false;
-            case 1: return getEnableColumn1();
-            case 2: return getEnableColumn2();
-            case 3: return getEnableColumn3();
-            case 4: return getEnableColumn4();
-            case 5: return getEnableColumn5();
-            case 6: return getEnableColumn6();
-            case 7: return getEnableColumn7();
-            case 8: return getEnableColumn8();
-        }
-    }
 }

--- a/src/main/java/com/github/nyuppo/config/HotbarCycleConfig.java
+++ b/src/main/java/com/github/nyuppo/config/HotbarCycleConfig.java
@@ -5,6 +5,8 @@ public abstract class HotbarCycleConfig {
     public abstract boolean getReverseCycleDirection();
     public abstract boolean getHoldAndScroll();
     public abstract boolean getRepeatSlotToCycle();
+    public abstract boolean getCycleWhenPickingBlock();
+    public abstract boolean getPickCyclesWholeHotbar();
 
     public abstract boolean getEnableRow1();
     public abstract boolean getEnableRow2();
@@ -19,4 +21,27 @@ public abstract class HotbarCycleConfig {
     public abstract boolean getEnableColumn6();
     public abstract boolean getEnableColumn7();
     public abstract boolean getEnableColumn8();
+
+    public boolean isRowEnabled(int y){
+        switch (y){
+            default: return false;
+            case 1: return getEnableRow1();
+            case 2: return getEnableRow2();
+            case 3: return getEnableRow3();
+        }
+    }
+
+    public boolean isColumnEnabled(int x){
+        switch (x){
+            default: return false;
+            case 1: return getEnableColumn1();
+            case 2: return getEnableColumn2();
+            case 3: return getEnableColumn3();
+            case 4: return getEnableColumn4();
+            case 5: return getEnableColumn5();
+            case 6: return getEnableColumn6();
+            case 7: return getEnableColumn7();
+            case 8: return getEnableColumn8();
+        }
+    }
 }

--- a/src/main/java/com/github/nyuppo/mixin/RepeatClickCycleMixin.java
+++ b/src/main/java/com/github/nyuppo/mixin/RepeatClickCycleMixin.java
@@ -1,9 +1,12 @@
 package com.github.nyuppo.mixin;
 
 import com.github.nyuppo.HotbarCycleClient;
+import com.github.nyuppo.HotbarCycleClient.Direction;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.option.GameOptions;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,6 +14,7 @@ import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MinecraftClient.class)
@@ -29,5 +33,20 @@ public class RepeatClickCycleMixin {
         if (HotbarCycleClient.getConfig().getRepeatSlotToCycle() && this.options.hotbarKeys[this.player.getInventory().selectedSlot].wasPressed()) {
             HotbarCycleClient.shiftSingle(((MinecraftClient)(Object)this), this.player.getInventory().selectedSlot, HotbarCycleClient.Direction.DOWN);
         }
+    }
+
+    @Redirect(method="doItemPick", at=@At(value="INVOKE", target="net/minecraft/entity/player/PlayerInventory.getSlotWithStack (Lnet/minecraft/item/ItemStack;)I"))
+    private int cyclePickedItem(PlayerInventory inventory, ItemStack pickedItem) {
+        int slot = inventory.getSlotWithStack(pickedItem);
+        if (slot < 0)
+            return slot;
+
+        int x = slot % 9;
+        int y = slot / 9;
+
+        for (int i=y; 0<i; --i)
+            HotbarCycleClient.shiftRows((MinecraftClient)(Object)this, Direction.DOWN);
+
+        return x;
     }
 }

--- a/src/main/java/com/github/nyuppo/mixin/RepeatClickCycleMixin.java
+++ b/src/main/java/com/github/nyuppo/mixin/RepeatClickCycleMixin.java
@@ -42,18 +42,18 @@ public class RepeatClickCycleMixin {
         int slot = inventory.getSlotWithStack(pickedItem);
         int x, y;
 
-        if (0<slot && config.getCycleWhenPickingBlock() && config.isColumnEnabled(x=slot%9) && config.isRowEnabled(y=slot/9))
+        if (8<slot && config.getCycleWhenPickingBlock() && HotbarCycleClient.isColumnEnabled(x=slot%9) && HotbarCycleClient.isRowEnabled(y=slot/9))
         {
             final MinecraftClient client = (MinecraftClient)(Object)this;
-            final Direction direction = Direction.UP.reverse(config.getReverseCycleDirection());
-            Runnable shiftOp;
-            if (config.getPickCyclesWholeHotbar())
-                shiftOp = ()->HotbarCycleClient.shiftRows(client, direction);
-            else
-                shiftOp = ()->HotbarCycleClient.shiftSingle(client, x, direction);
+            int direction = -1;
+            for (int i=1; i<y; ++i)
+                if (HotbarCycleClient.isRowEnabled(i))
+                    direction--;
 
-            for (int i=y; 0<i; --i)
-                shiftOp.run();
+            if (config.getPickCyclesWholeHotbar())
+                HotbarCycleClient.shiftRows(client, direction);
+            else
+                HotbarCycleClient.shiftSingle(client, x, direction);
 
             slot = x;
         }

--- a/src/main/resources/assets/hotbarcycle/lang/en_us.json
+++ b/src/main/resources/assets/hotbarcycle/lang/en_us.json
@@ -16,6 +16,10 @@
   "text.autoconfig.hotbarcycle.option.holdAndScroll.@Tooltip[1]": "(Replaces default functionality)",
   "text.autoconfig.hotbarcycle.option.repeatSlotToCycle": "Enable Repeat Slot to Cycle",
   "text.autoconfig.hotbarcycle.option.repeatSlotToCycle.@Tooltip": "Click the selected slot again to cycle it.",
+  "text.autoconfig.hotbarcycle.option.cycleWhenPickingBlock": "Cycle when picking blocks",
+  "text.autoconfig.hotbarcycle.option.cycleWhenPickingBlock.@Tooltip": "Targeted block will be cycled into your hotbar before selecting it.",
+  "text.autoconfig.hotbarcycle.option.pickCyclesWholeHotbar": "Picking cycles whole hotbar",
+  "text.autoconfig.hotbarcycle.option.pickCyclesWholeHotbar.@Tooltip": "Whether picking a block should cycle the whole hotbar, or only the approriate slot.",
 
   "text.autoconfig.hotbarcycle.option.enableRow1": "Enable Row 1",
   "text.autoconfig.hotbarcycle.option.enableRow1.@Tooltip": "(Directly Above the Hotbar)",


### PR DESCRIPTION
Currently, when picking a block, if the corresponding item is in your inventory, but not your hotbar, the item will be swapped into your currently selected slot.

With this PR, the mod will first attempt to cycle the item into the hotbar, and then select the corresponding slot.

- [x] Users have the choice to cycle either the whole hotbar, only the appropriate slot, or to disable the feature entirely.
- [x] Disabled rows and columns are respected. If the item is in a disabled slot, vanilla mechanics apply instead.

I implented my own version of `shiftRows` and `shiftSingle`. They accept an arbitrary offset as an argument, instead of just Up or Down, so they end up sending less packets to the server than repeated calls to the old ones. 
The old implementations could be made to rely onto those, but I preferred to leave them untouched for now.

I'm using two boolean options in the config. 
I think a single three-choices (enum?) option would be more intuitive, but I'm not familiar enough with cloth-config to make it look clean in the config screen.

If this is accepted, I'll also make a PR for a 1.19.4 backport (which I still play on)